### PR TITLE
Add :focus support for keyboard navigation

### DIFF
--- a/css/buttons.css
+++ b/css/buttons.css
@@ -121,7 +121,7 @@
   text-align: center;
 }
 /* line 42, ../scss/partials/_buttons.scss */
-.button:hover {
+.button:hover .button:focus {
   background-color: #eeeeee;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #dcdcdc));
   background: -webkit-linear-gradient(top, #ffffff, #dcdcdc);
@@ -158,6 +158,7 @@ input.button, button.button {
 /* line 74, ../scss/partials/_buttons.scss */
 .button.disabled,
 .button.disabled:hover,
+.button.disabled:focus,
 .button.disabled:active,
 input.button:disabled,
 button.button:disabled {
@@ -211,7 +212,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 105, ../scss/partials/_buttons.scss */
-.button-flat:hover {
+.button-flat:hover, .button-flat:focus {
   background: #fbfbfb;
 }
 /* line 108, ../scss/partials/_buttons.scss */
@@ -250,7 +251,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 132, ../scss/partials/_buttons.scss */
-.button-border:hover {
+.button-border:hover, .button-border:focus {
   background: none;
   color: gray;
   border: 2px solid gray;
@@ -299,7 +300,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 165, ../scss/partials/_buttons.scss */
-.button-3d:hover {
+.button-3d:hover, .button-3d:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #bbbbbb, 0px 8px 3px rgba(0, 0, 0, 0.2);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #bbbbbb, 0px 8px 3px rgba(0, 0, 0, 0.2);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #bbbbbb, 0px 8px 3px rgba(0, 0, 0, 0.2);
@@ -382,7 +383,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(0, 40, 50, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-primary:hover {
+.button-primary:hover, .button-primary:focus {
   background-color: #00a1cb;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #00c9fe), color-stop(100%, #008db2));
   background: -webkit-linear-gradient(top, #00c9fe, #008db2);
@@ -422,7 +423,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-primary:hover {
+.button-3d-primary:hover, .button-3d-primary:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #00708e, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #00708e, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #00708e, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -475,7 +476,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-primary:hover {
+.button-border-primary:hover, .button-border-primary:focus {
   background: none;
   color: #00c9fe;
   border: 2px solid #00c9fe;
@@ -517,7 +518,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-primary:hover {
+.button-flat-primary:hover, .button-flat-primary:focus {
   background: #00b5e5;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -550,7 +551,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(179, 179, 179, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-secondary:hover {
+.button-secondary:hover, .button-secondary:focus {
   background-color: white;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #f2f2f2));
   background: -webkit-linear-gradient(top, #ffffff, #f2f2f2);
@@ -590,7 +591,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-secondary:hover {
+.button-3d-secondary:hover, .button-3d-secondary:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #e0e0e0, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #e0e0e0, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #e0e0e0, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -643,7 +644,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-secondary:hover {
+.button-border-secondary:hover, .button-border-secondary:focus {
   background: none;
   color: white;
   border: 2px solid white;
@@ -685,7 +686,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-secondary:hover {
+.button-flat-secondary:hover, .button-flat-secondary:focus {
   background: white;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -718,7 +719,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(19, 28, 0, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-action:hover {
+.button-action:hover, .button-action:focus {
   background-color: #7db500;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #a0e800), color-stop(100%, #6b9c00));
   background: -webkit-linear-gradient(top, #a0e800, #6b9c00);
@@ -758,7 +759,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-action:hover {
+.button-3d-action:hover, .button-3d-action:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #537800, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #537800, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #537800, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -811,7 +812,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-action:hover {
+.button-border-action:hover, .button-border-action:focus {
   background: none;
   color: #a0e800;
   border: 2px solid #a0e800;
@@ -853,7 +854,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-action:hover {
+.button-flat-action:hover, .button-flat-action:focus {
   background: #8fcf00;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -886,7 +887,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(91, 53, 2, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-highlight:hover {
+.button-highlight:hover, .button-highlight:focus {
   background-color: #f18d05;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #fba42e), color-stop(100%, #d87e04));
   background: -webkit-linear-gradient(top, #fba42e, #d87e04);
@@ -926,7 +927,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-highlight:hover {
+.button-3d-highlight:hover, .button-3d-highlight:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b56a04, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b56a04, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b56a04, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -979,7 +980,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-highlight:hover {
+.button-border-highlight:hover, .button-border-highlight:focus {
   background: none;
   color: #fba42e;
   border: 2px solid #fba42e;
@@ -1021,7 +1022,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-highlight:hover {
+.button-flat-highlight:hover, .button-flat-highlight:focus {
   background: #fa9915;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -1054,7 +1055,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(103, 24, 13, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-caution:hover {
+.button-caution:hover, .button-caution:focus {
   background-color: #e54028;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #eb6855), color-stop(100%, #d9331a));
   background: -webkit-linear-gradient(top, #eb6855, #d9331a);
@@ -1094,7 +1095,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-caution:hover {
+.button-3d-caution:hover, .button-3d-caution:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b92b16, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b92b16, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #b92b16, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -1147,7 +1148,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-caution:hover {
+.button-border-caution:hover, .button-border-caution:focus {
   background: none;
   color: #eb6855;
   border: 2px solid #eb6855;
@@ -1189,7 +1190,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-caution:hover {
+.button-flat-caution:hover, .button-flat-caution:focus {
   background: #e8543f;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -1222,7 +1223,7 @@ button.button:disabled {
   text-shadow: 0 -1px 1px rgba(26, 9, 27, 0.35);
 }
 /* line 233, ../scss/partials/_buttons.scss */
-.button-royal:hover {
+.button-royal:hover, .button-royal:focus {
   background-color: #87318c;
   background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ab3eb2), color-stop(100%, #752a79));
   background: -webkit-linear-gradient(top, #ab3eb2, #752a79);
@@ -1262,7 +1263,7 @@ button.button:disabled {
   top: 0px;
 }
 /* line 262, ../scss/partials/_buttons.scss */
-.button-3d-royal:hover {
+.button-3d-royal:hover, .button-3d-royal:focus {
   -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #5b215f, 0px 8px 3px rgba(0, 0, 0, 0.3);
   -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #5b215f, 0px 8px 3px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.3), inset 0px -1px 1px rgba(255, 255, 255, 0.15), 0px 7px 0px #5b215f, 0px 8px 3px rgba(0, 0, 0, 0.3);
@@ -1315,7 +1316,7 @@ button.button:disabled {
   text-shadow: none;
 }
 /* line 298, ../scss/partials/_buttons.scss */
-.button-border-royal:hover {
+.button-border-royal:hover, .button-border-royal:focus {
   background: none;
   color: #ab3eb2;
   border: 2px solid #ab3eb2;
@@ -1357,7 +1358,7 @@ button.button:disabled {
   border: none;
 }
 /* line 330, ../scss/partials/_buttons.scss */
-.button-flat-royal:hover {
+.button-flat-royal:hover, .button-flat-royal:focus {
   background: #99389f;
 }
 /* line 333, ../scss/partials/_buttons.scss */
@@ -1576,7 +1577,7 @@ input.button-tiny, button.button-tiny {
   white-space: nowrap;
 }
 /* line 521, ../scss/partials/_buttons.scss */
-.button-dropdown ul a:hover {
+.button-dropdown ul a:hover, .button-dropdown ul a:focus {
   background-color: #3c6ab9;
   color: white;
 }

--- a/scss/partials/_buttons.scss
+++ b/scss/partials/_buttons.scss
@@ -39,7 +39,7 @@ $unicorn-btn-largefs: inherit;
     text-decoration: none;
     text-align: center;
 
-    &:hover {
+    &:hover, &:focus {
         background-color: $unicorn-btn-bgcolor;
         @include background(linear-gradient(top,  lighten($unicorn-btn-bgcolor, 10%), darken($unicorn-btn-bgcolor, 7%)));
     }
@@ -69,6 +69,7 @@ input#{$unicorn-btn-namespace}, button#{$unicorn-btn-namespace} {
 // DISABLED STATE
 #{$unicorn-btn-namespace}.disabled,
 #{$unicorn-btn-namespace}.disabled:hover,
+#{$unicorn-btn-namespace}.disabled:focus,
 #{$unicorn-btn-namespace}.disabled:active,
 input#{$unicorn-btn-namespace}:disabled,
 button#{$unicorn-btn-namespace}:disabled {
@@ -102,7 +103,7 @@ button#{$unicorn-btn-namespace}:disabled {
         border: none;
         text-shadow: none;
 
-        &:hover {
+        &:hover, &:focus {
             background: lighten($unicorn-btn-background, 5%);
         }
         &:active {
@@ -129,7 +130,7 @@ button#{$unicorn-btn-namespace}:disabled {
         background: none;
         text-shadow: none;
 
-        &:hover {
+        &:hover, &:focus {
             background: none;
             color: lighten($unicorn-btn-font-color, 10%);
             border: 2px solid lighten($unicorn-btn-font-color, 10%);
@@ -162,7 +163,7 @@ button#{$unicorn-btn-namespace}:disabled {
         position: relative;
         top: 0px;
 
-        &:hover {
+        &:hover, &:focus {
             @include box-shadow(inset 0px 1px 0px rgba(255, 255, 255, .3), inset 0px -1px 1px rgba(255, 255, 255, .15), 0px 7px 0px darken($unicorn-btn-bgcolor, 20%), 0px 8px 3px rgba(0, 0, 0, .2));
             @include background(linear-gradient(top,  lighten($unicorn-btn-bgcolor, 8%), darken($unicorn-btn-bgcolor, 1%)));
             background-color: lighten($unicorn-btn-bgcolor, 10%);
@@ -230,7 +231,7 @@ button#{$unicorn-btn-namespace}:disabled {
         color: $unicorn-btn-color;
         text-shadow: 0 -1px 1px rgba(darken($unicorn-btn-background, 30%), 0.35);
 
-        &:hover {
+        &:hover, &:focus {
             background-color: $unicorn-btn-background;
             @include background(linear-gradient(top,  lighten($unicorn-btn-background, 10%), darken($unicorn-btn-background, 5%)));
         }
@@ -259,7 +260,7 @@ button#{$unicorn-btn-namespace}:disabled {
             position: relative;
             top: 0px;
 
-            &:hover {
+            &:hover, &:focus {
                 @include box-shadow(inset 0px 1px 0px rgba(255, 255, 255, .3), inset 0px -1px 1px rgba(255, 255, 255, .15), 0px 7px 0px darken($unicorn-btn-background, 12%), 0px 8px 3px rgba(0, 0, 0, .30));
                 @include background(linear-gradient(top,  lighten($unicorn-btn-background, 8%), darken($unicorn-btn-background, 1%)));
                 background-color: lighten($unicorn-btn-background, 10%);
@@ -295,7 +296,7 @@ button#{$unicorn-btn-namespace}:disabled {
             background: none;
             text-shadow: none;
 
-            &:hover {
+            &:hover, &:focus {
                 background: none;
                 color: lighten($unicorn-btn-background, 10%);
                 border: 2px solid lighten($unicorn-btn-background, 10%);
@@ -327,7 +328,7 @@ button#{$unicorn-btn-namespace}:disabled {
             text-shadow: none;
             border: none;
 
-            &:hover {
+            &:hover, &:focus {
                 background: lighten($unicorn-btn-background, 5%);
             }
             &:active {
@@ -518,7 +519,7 @@ button#{$unicorn-btn-namespace}:disabled {
                 line-height: 30px;
                 white-space: nowrap;
 
-                &:hover {
+                &:hover, &:focus {
                     background-color: $unicorn-btn-dropdown-link-hover-background;
                     color: $unicorn-btn-dropdown-link-hover;
                 }


### PR DESCRIPTION
Improves usability by toggling :hover styles when inputs are :focus(ed) with "Tab" keyboard key.
