### PR TITLE
Update README.md fix punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We've made some major improvements to the Buttons library. In order to integrate
 
 1. Compass has been replaced with [autoprefixer](https://github.com/postcss/autoprefixer). Compass is not recommended but it is still supported.
 2. Button colors are now completely independent (ex. button-primary). We no longer have classes like <code>button-flat-primary</code>, so to achieve this you now simply add <code>button-flat button-primary</code>
-3. Buttons styles are now independent (ex. button-flat, button-3d, etc.). You can apply these styles and they will automatically pick up the color attached to the button (ex. button-primary button-3d)
+3. Buttons styles are now independent (ex. button-flat, button-3d, etc.). You can apply these styles and they will automatically pick up the color attached to the button (ex. button-primary button-3d).
 
 ## Customize Buttons (Recommended uses Sass & Autoprefixer)
 0. Clone the Buttons repository.


### PR DESCRIPTION
Added missing period at the end of third list item.

BEFORE: "You can apply these styles and they will automatically pick up the color attached to the button (ex. button-primary button-3d)"
AFTER: "You can apply these styles and they will automatically pick up the color attached to the button (ex. button-primary button-3d)."
