### PR TITLE
Move grunt to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-includes": "^0.4.5",
     "grunt-saucelabs": "^8.3.2",
-    "webpack": "^1.4.5"
-  },
-  "dependencies": {
+    "webpack": "^1.4.5",
     "grunt": "^0.4.5",
     "grunt-saucelabs": "^8.3.2"
+  },
+  "dependencies": {
   }
 }


### PR DESCRIPTION
Have issue installing grunt on node4/npm3.

It says some packages in my project are incompatible with others.
Sorry for that I forgot to copy the error message.

I moved grunt to devDependencies to get the installation work.