### PR TITLE
Add "width: 100%" to support -block on <button> tag

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -6,4 +6,5 @@
 #{$ubtn-namespace}-block,
 #{$ubtn-namespace}-stacked {
   display: block;
+  width: 100%;
 }


### PR DESCRIPTION
I add width: 100% to support Block level buttons on  <button> tag